### PR TITLE
Add lighter to jinx-mode

### DIFF
--- a/jinx.el
+++ b/jinx.el
@@ -678,6 +678,7 @@ If prefix argument ALL non-nil correct all misspellings."
 ;;;###autoload
 (define-minor-mode jinx-mode
   "Enchanted Spell Checker."
+  :lighter (when jinx-mode "Jinx")
   :global nil :group 'jinx :keymap jinx-mode-map
   (cond
    (jinx-mode


### PR DESCRIPTION
This way, you see that jinx is active in the mode line and click on the indicator in the mode line to disable it.
Plans: add the possibility of changing the active dictionary by clicking on the jinx indicator in the mode line