### PR TITLE
Try searching the whole load-path for jinx-mod

### DIFF
--- a/jinx.el
+++ b/jinx.el
@@ -472,6 +472,11 @@ If VISIBLE is non-nil, only include visible overlays."
     (let ((default-directory
            (file-name-directory (locate-library "jinx.el" t)))
           (module (file-name-with-extension "jinx-mod" module-file-suffix)))
+
+      (let ((located-module (locate-library module)))
+            (when located-module
+              (setq module located-module)))
+
       (unless (file-exists-p module)
         (let ((command
                `("cc" "-I." "-O2" "-Wall" "-Wextra" "-fPIC" "-shared"


### PR DESCRIPTION
* jinx.el (jinx--load-module): Try to (locate-library module) before trying to look for a sibling file of jinx.el.


Hi there!

I'm trying to get Jinx packaged in Gentoo, and for that I needed to compile and install the native module as a part of the package.

Customarily, we install native modules to a path akin to `/usr/lib64/emacs/modules/jinx/`, which we add to load-path, meaning that locate-library should be able to find it, but the current code does not search load-path, but instead checks for a sibling file of jinx.el.

Adding this allows both pieces of behavior to happen.

TIA, have a lovely night.