### PR TITLE
Use interactive list in jinx-languages

### DIFF
--- a/jinx.el
+++ b/jinx.el
@@ -748,30 +748,31 @@ If SAVE is non-nil save, otherwise format candidate given action KEY."
 ;;;; Public commands
 
 ;;;###autoload
-(defun jinx-languages (&optional global)
+(defun jinx-languages (global langs)
   "Change languages locally or globally.
 With prefix argument GLOBAL non-nil change the languages globally."
-  (interactive "*P")
+  (interactive (list
+                current-prefix-arg
+                (string-join
+                 (completing-read-multiple
+                  (format "Change languages (%s): "
+                          (string-join (split-string jinx-languages) ", "))
+                  (delete-dups (jinx--mod-langs)) nil t)
+                 " ")))
   (jinx--load-module)
-  (when-let ((langs
-              (completing-read-multiple
-               (format "Change languages (%s): "
-                       (string-join (split-string jinx-languages) ", "))
-               (delete-dups (jinx--mod-langs)) nil t)))
-    (setq langs (string-join langs " "))
-    (cond
-     (global
-      (kill-local-variable 'jinx-languages)
-      (setq-default jinx-languages langs))
-     (t
+  (if global ;; called with C-u
+      (progn
+        (kill-local-variable 'jinx-languages)
+        (setq-default jinx-languages langs))
+    (progn
       (setq-local jinx-languages langs)
       (when (or (assq 'jinx-languages file-local-variables-alist)
                 (and buffer-file-name
                      (y-or-n-p "Save `jinx-languages' as file-local variable? ")))
         (add-file-local-variable 'jinx-languages jinx-languages)
         (setf (alist-get 'jinx-languages file-local-variables-alist) jinx-languages))))
-    (jinx--load-dicts)
-    (jinx--cleanup)))
+  (jinx--load-dicts)
+  (jinx--cleanup))
 
 ;;;###autoload
 (defun jinx-correct (&optional all)


### PR DESCRIPTION
Using `(interactive (list` doesn't change the functionality, but allows one to write code like
```
(jinx-languages t "en_US")
```
