### PR TITLE
Replace javascript-mode with js-mode in jinx-camel-modes

### DIFF
--- a/jinx.el
+++ b/jinx.el
@@ -94,7 +94,7 @@ checking."
   :type '(alist :key-type symbol :value-type (repeat face)))
 
 (defcustom jinx-camel-modes
-  '(java-mode javascript-mode java-ts-mode javascript-ts-mode ruby-mode
+  '(java-mode js-mode java-ts-mode javascript-ts-mode ruby-mode
     ruby-ts-mode rust-mode rust-ts-mode haskell-mode kotlin-mode swift-mode
     csharp-mode csharp-ts-mode objc-mode typescript-ts-mode typescript-mode
     python-mode python-ts-mode dart-mode go-mode go-ts-mode scala-mode


### PR DESCRIPTION
The former is an alias of the later. Passing the alias to
`derived-mode-p` doesn't work. I would consider this to be a bug in
Emacs.