### PR TITLE
Allow customizing word validity predicates

### DIFF
--- a/jinx.el
+++ b/jinx.el
@@ -108,6 +108,13 @@ checking."
 Set to t to enable camelCase everywhere."
   :type '(choice (const t) (repeat symbol)))
 
+(defcustom jinx-word-valid-predicates
+  (list
+   #'jinx--word-in-dict-p
+   #'jinx--word-in-session-words-p)
+  "List of predicates to check if a word is valid."
+  :type '(repeat function))
+
 (defcustom jinx-exclude-faces
   '((markdown-mode
      markdown-code-face markdown-html-attr-name-face
@@ -352,17 +359,25 @@ Predicate may return a position to skip forward.")
 
 (defun jinx--word-valid-p (start)
   "Return non-nil if word at START is valid."
-  (let ((word (buffer-substring-no-properties start (point)))
-        case-fold-search)
+  (let ((word (buffer-substring-no-properties start (point))))
+    (cl-loop for pred in jinx-word-valid-predicates
+             thereis (funcall pred word))))
+
+(defun jinx--word-in-dict-p (word)
+  "Return non-nil if WORD is in a dictionary."
+  (cl-loop for dict in jinx--dicts
+           thereis (jinx--mod-check dict word)))
+
+(defun jinx--word-in-session-words-p (word)
+  "Return non-nil if WORD is in session words."
+  (let (case-fold-search)
     (or (member word jinx--session-words)
         ;; Allow capitalized words
         (and (string-match-p "\\`[[:upper:]]" word)
              (cl-loop
               for w in jinx--session-words
               thereis (and (eq t (compare-strings word 0 1   w 0 1   t))
-                           (eq t (compare-strings word 1 nil w 1 nil nil)))))
-        (cl-loop for dict in jinx--dicts
-                 thereis (jinx--mod-check dict word)))))
+                           (eq t (compare-strings word 1 nil w 1 nil nil))))))))
 
 ;;;; Internal functions
 

--- a/jinx.el
+++ b/jinx.el
@@ -108,13 +108,6 @@ checking."
 Set to t to enable camelCase everywhere."
   :type '(choice (const t) (repeat symbol)))
 
-(defcustom jinx-word-valid-predicates
-  (list
-   #'jinx--word-in-dict-p
-   #'jinx--word-in-session-words-p)
-  "List of predicates to check if a word is valid."
-  :type '(repeat function))
-
 (defcustom jinx-exclude-faces
   '((markdown-mode
      markdown-code-face markdown-html-attr-name-face
@@ -360,8 +353,8 @@ Predicate may return a position to skip forward.")
 (defun jinx--word-valid-p (start)
   "Return non-nil if word at START is valid."
   (let ((word (buffer-substring-no-properties start (point))))
-    (cl-loop for pred in jinx-word-valid-predicates
-             thereis (funcall pred word))))
+    (or (jinx--word-in-dict-p word)
+        (jinx--word-in-session-words-p word))))
 
 (defun jinx--word-in-dict-p (word)
   "Return non-nil if WORD is in a dictionary."


### PR DESCRIPTION
I want to express an idea I had after seeing your https://github.com/minad/jinx/commit/fe82400abbd324ceb6e3c4c2df1a619588021e8e commit.

Currently, it's a little difficult to modify `jinx--word-valid-p` because the rules are hard-coded in the body. I'm thinking how it would be like if we make the rules customizable.

This allows the user to easily tweak existing rules. For example, if the user's language doesn't follow English capitalization rules, he may find the matching on capitalization wrong or at least excessive.

And it will also grant the user freedom to define new rules - here's a practical example:

```emacs-lisp
(defun jinx--english-possessive-p (word)
  "Return non-nil if WORD is a valid English possessive."
  (and (string-suffix-p "'s" word)
       (or (jinx--word-in-dict-p (substring word 0 -2))
           (jinx--word-in-session-words-p (substring word 0 -2)))))
```

This PR aims to demonstrate my idea on how it can make above two usages more convenient. Without these changes these needs can still be satisfied by advising `jinx--word-valid-p`, but then it will be a little convoluted.