### PR TITLE
Mention deps rpm distros with pkgconf and openSUSE package

### DIFF
--- a/README.org
+++ b/README.org
@@ -53,7 +53,9 @@ Linux distribution you have to install different packages:
 - Arch, Gentoo: =enchant=, =pkgconf=
 - Guix: =emacs-jinx= or =enchant=, =pkgconf=
 - NixOS: =jinx= from =elpa-packages.nix=
-- Void, Fedora: =enchant2-devel=, =pkgconf=
+- Void: enchant2-devel, pkgconf
+- RPM based such as Fedora or openSUSE: =pkgconfig(enchant2)=
+- openSUSE Tumbleweed: Either emacs-jinx or =pkgconfig(enchant2)=
 - FreeBSD, OpenBSD, Mac: =enchant2=, =pkgconf=
 
 On Windows the installation of the native module may require manual


### PR DESCRIPTION
In rpm based distributions dependencies can be installed using
pkgconfig symbols instead of plain package names, the benefit is that
this will use the pkgconfig name which is also used in the jinx itself
and the name of package doesn't matter anymore.

Also mention openSUSE Tumbleweed package similar to the Guix package
which is already mentioned.