### PR TITLE
New strategy for saving jinx-languages

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -5,6 +5,9 @@
 * Development
 
 - ~jinx--word-valid-p~: Do not error on invalid characters.
+- New custom variable ~jinx-save-languages~ with values ~'always~, ~'ask~ and
+  ~'never~ to control when the "Save `jinx-languages' as file-local variable?"
+  message is shown.
 
 * Version 1.6 (2024-04-12)
 

--- a/jinx.el
+++ b/jinx.el
@@ -177,15 +177,16 @@ checking."
 (put 'jinx-mode 'safe-local-variable #'not)
 
 (defcustom jinx-save-languages 'ask
-  "Ask user whether to save jinx-languages when it is changed
-in the local variables list.
+  "Should user be asked whether to save jinx-languages when it is changed
+in the local variables list?
 
 Values are:
- ask: ask whether to save
- never: don't save it in any case
+ ask:    ask whether to save
+ never:  don't save it in any case
  always: save without asking"
-  :type 'symbol
-  :options '(always ask never))
+    :type '(choice (const :tag "Ask"    ask)
+                   (const :tag "Never"  never)
+                   (const :tag "Always" always)))
 
 ;;;; Faces
 

--- a/jinx.el
+++ b/jinx.el
@@ -176,7 +176,7 @@ checking."
 ;;;###autoload
 (put 'jinx-mode 'safe-local-variable #'not)
 
-(defcustom jinx-ask-save-languages 'ask
+(defcustom jinx-save-languages 'ask
   "Ask user whether to save jinx-languages when it is changed
 in the local variables list.
 

--- a/jinx.el
+++ b/jinx.el
@@ -181,10 +181,11 @@ checking."
 in the local variables list.
 
 Values are:
-ask: ask whether to save
-never: don't save it in any case
-always: save without asking"
-  :type 'symbol)
+ ask: ask whether to save
+ never: don't save it in any case
+ always: save without asking"
+  :type 'symbol
+  :options '(always ask never))
 
 ;;;; Faces
 


### PR DESCRIPTION
I was a bit bored because I always got the 'Save jinx-languages ...' question. I have defined a variable alias to have a uniform interface from jinx and "legacy" ispell to be interoperable and that message has become a bit too intrusive..
