### PR TITLE
jinx.el: refresh mode-line from (jinx-languages ...)

### DIFF
--- a/jinx.el
+++ b/jinx.el
@@ -947,6 +947,7 @@ buffers.  See also the variable `jinx-languages'."
                 jinx-save-languages))
       (add-file-local-variable 'jinx-languages jinx-languages)
       (setf (alist-get 'jinx-languages file-local-variables-alist) jinx-languages))))
+  (force-mode-line-update t) ; Make sure change is reflected in mode line
   (jinx--load-dicts)
   (jinx--cleanup))
 


### PR DESCRIPTION
I'm currently watching jinx-languages from my code and updating the mode line after changes.
I observed hick-ups in the sense that the mode line was sometimes not updated.
