### PR TITLE
Add include and linkpaths from FreeBSD

### DIFF
--- a/jinx.el
+++ b/jinx.el
@@ -597,7 +597,7 @@ If CHECK is non-nil, always check first."
                   ,@(split-string-and-unquote
                      (condition-case nil
                          (car (process-lines "pkg-config" "--cflags" "--libs" "enchant-2"))
-                       (error "-I/usr/include/enchant-2 -I/usr/local/include/enchant-2 -lenchant-2"))))))
+                       (error "-I/usr/include/enchant-2 -I/usr/local/include/enchant-2 -L/usr/local/lib -lenchant-2"))))))
           (with-current-buffer (get-buffer-create "*jinx module compilation*")
             (let ((inhibit-read-only t))
               (erase-buffer)

--- a/jinx.el
+++ b/jinx.el
@@ -597,7 +597,7 @@ If CHECK is non-nil, always check first."
                   ,@(split-string-and-unquote
                      (condition-case nil
                          (car (process-lines "pkg-config" "--cflags" "--libs" "enchant-2"))
-                       (error "-I/usr/include/enchant-2 -lenchant-2"))))))
+                       (error "-I/usr/include/enchant-2 -I/usr/local/include/enchant-2 -lenchant-2"))))))
           (with-current-buffer (get-buffer-create "*jinx module compilation*")
             (let ((inhibit-read-only t))
               (erase-buffer)


### PR DESCRIPTION
In FreeBSD things are a bit different and the libs are installed in /usr/local

FFS: create different command lines for FreeBSD and the rest

```
(defvar cc-flags-fallback
  (if (eq system-type 'berkeley-unix)
   "-I/usr/local/include/enchant-2 -L/usr/local/lib -lenchant-2"
  "-I/usr/include/enchant-2 -lenchant-2")
"Fallback compilation command line")
```
and use it as `(error cc-flags-fallback`)