### PR TITLE
Dynamic module enhancements

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,2 @@
+jinx-mod-x86_64.dylib: jinx-mod.c
+	gcc -I. -O2 -Wall -Wextra -fPIC -shared -o $@ $< $$(pkg-config --cflags --libs enchant-2)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,2 +1,4 @@
-jinx-mod-x86_64.dylib: jinx-mod.c
+ARCH := $(shell uname -m)
+
+jinx-mod-$(ARCH).dylib: jinx-mod.c
 	gcc -I. -O2 -Wall -Wextra -fPIC -shared -o $@ $< $$(pkg-config --cflags --libs enchant-2)


### PR DESCRIPTION
- Module object file name now includes target architecture. This enables sharing a jinx installation on multiple platforms.

- Report the libenchant version loaded. Previously, jinx was silent except for a version deprecation warning.

- Respect ENCHANT_CONFIG_DIR either as inherited from the environment on Emacs startup or as explicitly set as an Emacs process environment variable. This enables a non-default enchant configuration directory.

- GNUmakefile was added to aid compilation testing outside of Emacs.