### PR TITLE
README: warn about gentoo use flag

### DIFF
--- a/README.org
+++ b/README.org
@@ -60,6 +60,9 @@ Linux distribution you have to install different packages:
 On Windows the installation of the native module may require manual
 intervention.
 
+On Gentoo make sure to compile Emacs with the 'dynamic-loading' use
+flag.
+
 * Configuration
 
 Jinx has two modes: the command, =global-jinx-mode= activates globally; and the


### PR DESCRIPTION
Add a small amount of text for Gentoo users on the README file.

When compiled without 'dynamic-loading' jinx would fail with "Dynamic Modules are not supported". I was troubled with this
until I figured it was an emacs-specific issue and not jinx. Hopefully, this will clear up confusion for emacs and Gentoo beginners
and make jinx plug and play like it's supposed to be.
