### PR TITLE
Add tsx-ts-mode to jinx-camel-modes

### DIFF
--- a/jinx.el
+++ b/jinx.el
@@ -109,8 +109,8 @@ checking."
 (defcustom jinx-camel-modes
   '(java-mode java-ts-mode js-mode js-ts-mode ruby-mode ruby-ts-mode rust-mode
     rust-ts-mode haskell-mode kotlin-mode swift-mode csharp-mode csharp-ts-mode
-    objc-mode typescript-ts-mode typescript-mode python-mode python-ts-mode
-    dart-mode go-mode go-ts-mode scala-mode groovy-mode)
+    objc-mode typescript-ts-mode typescript-mode tsx-ts-mode python-mode
+    python-ts-mode dart-mode go-mode go-ts-mode scala-mode groovy-mode)
   "Modes where camelCase or PascalCase words should be accepted.
 Set to t to enable camelCase everywhere."
   :type '(choice (const t) (repeat symbol)))


### PR DESCRIPTION
`tsx-ts-mode` is essentially a variant of `typescript-ts-mode`, so should also be included in `jinx-camel-modes`.