### PR TITLE
Suggest Jinx package for Fedora

### DIFF
--- a/README.org
+++ b/README.org
@@ -56,7 +56,7 @@ different packages:
 - Guix: =emacs-jinx= defined in =emacs-xyz.scm=
 - Nix: =jinx= defined in =elpa-packages.nix=
 - Void: =enchant2-devel=, =pkgconf=
-- Fedora: =enchant2-devel=, =pkgconf-pkg-config=
+- Fedora: =emacs-jinx= or =enchant2-devel=, =pkgconf-pkg-config=
 - OpenSUSE: =emacs-jinx= or =enchant-devel=, =pkgconf-pkg-config=
 - FreeBSD, OpenBSD, Mac: =enchant2=, =pkgconf=
 


### PR DESCRIPTION
Jinx is now packaged for Fedora 44 onwards (due for release in April 2026).  You may prefer not to merge this until then, but I’m raising it now so that I don’t forget.